### PR TITLE
Add basic DB pipeline and utilities

### DIFF
--- a/scripts/REPORT.md
+++ b/scripts/REPORT.md
@@ -16,7 +16,11 @@ and stub functionality for trade uploads and backtesting.
 - **broker_upload.py** – Stub implementation for uploading trades to a broker's
   API.
 - **backtesting_agent.py** – Contains a minimal example backtesting function that
-  calculates a buy-and-hold return.
+  calculates a buy-and-hold return and stores results per strategy.
+- **trading_db.py** – Defines tables for trading rules, strategies and backtest
+  records.
+- **gui.py** – Streamlit application for managing rules, strategies, and running
+  backtests using OpenBB price data.
 
 These scripts establish a basic framework for connecting to databases, managing
 those connections, previewing fetched data, and preparing for trade execution

--- a/scripts/REPORT.md
+++ b/scripts/REPORT.md
@@ -1,0 +1,24 @@
+# Pipeline and Agent Setup Report
+
+This report documents the scripts added to the repository to manage database
+connections, collect price data, preview data before loading into a database,
+and stub functionality for trade uploads and backtesting.
+
+## Overview of Added Scripts
+
+- **db_connections.py** – Provides a `ConnectionManager` class for creating and
+  managing SQLite connections. Connection configurations are stored in the
+  `scripts/configs` directory.
+- **db_agent.py** – Interfaces with the `ollama` command line tool to help
+  troubleshoot connection issues using a local language model.
+- **data_pipeline.py** – Demonstrates retrieving price data from the OpenBB
+  package and loading it into a `prices` table. Includes a preview helper.
+- **broker_upload.py** – Stub implementation for uploading trades to a broker's
+  API.
+- **backtesting_agent.py** – Contains a minimal example backtesting function that
+  calculates a buy-and-hold return.
+
+These scripts establish a basic framework for connecting to databases, managing
+those connections, previewing fetched data, and preparing for trade execution
+and backtesting workflows.
+

--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,0 +1,16 @@
+"""Helper scripts for OpenBB extensions."""
+
+__all__ = [
+    "ConnectionManager",
+    "fetch_equity",
+    "run_backtest",
+    "run_strategy_backtest",
+    "add_rule",
+    "add_strategy",
+    "initialize_db",
+]
+
+from .backtesting_agent import run_backtest, run_strategy_backtest
+from .data_pipeline import fetch_equity
+from .db_connections import ConnectionManager
+from .trading_db import add_rule, add_strategy, initialize_db

--- a/scripts/backtesting_agent.py
+++ b/scripts/backtesting_agent.py
@@ -2,6 +2,9 @@
 
 import pandas as pd
 
+from .db_connections import ConnectionManager
+from .trading_db import list_strategies, record_backtest
+
 
 def run_backtest(prices: pd.DataFrame) -> dict:
     """Simple backtest: buy and hold return."""
@@ -11,4 +14,20 @@ def run_backtest(prices: pd.DataFrame) -> dict:
     start = prices["close"].iloc[0]
     end = prices["close"].iloc[-1]
     return {"return": (end - start) / start}
+
+
+def run_strategy_backtest(
+    strategy_id: int,
+    prices: pd.DataFrame,
+    conn_manager: ConnectionManager,
+) -> dict:
+    """Backtest a strategy and store the result."""
+    strategies = {s["id"]: s for s in list_strategies(conn_manager)}
+    strategy = strategies.get(strategy_id)
+    if strategy is None:
+        raise ValueError(f"Strategy {strategy_id} not found")
+
+    result = run_backtest(prices)
+    record_backtest(strategy_id, "", "", result, conn_manager)
+    return result
 

--- a/scripts/backtesting_agent.py
+++ b/scripts/backtesting_agent.py
@@ -1,0 +1,14 @@
+"""Backtesting agent placeholder."""
+
+import pandas as pd
+
+
+def run_backtest(prices: pd.DataFrame) -> dict:
+    """Simple backtest: buy and hold return."""
+    if prices.empty:
+        return {"return": 0.0}
+
+    start = prices["close"].iloc[0]
+    end = prices["close"].iloc[-1]
+    return {"return": (end - start) / start}
+

--- a/scripts/backtesting_agent.py
+++ b/scripts/backtesting_agent.py
@@ -29,6 +29,8 @@ def run_strategy_backtest(
         raise ValueError(f"Strategy {strategy_id} not found")
 
     result = run_backtest(prices)
-    record_backtest(strategy_id, "", "", result, conn_manager)
+    start_date = str(prices["date"].iloc[0]) if "date" in prices.columns else ""
+    end_date   = str(prices["date"].iloc[-1]) if "date" in prices.columns else ""
+    record_backtest(strategy_id, start_date, end_date, result, conn_manager)
     return result
 

--- a/scripts/backtesting_agent.py
+++ b/scripts/backtesting_agent.py
@@ -12,7 +12,8 @@ def run_backtest(prices: pd.DataFrame) -> dict:
         return {"return": 0.0}
 
     start = prices["close"].iloc[0]
-    end = prices["close"].iloc[-1]
+    if start == 0:
+        return {"return": float('inf') if end > 0 else 0.0}
     return {"return": (end - start) / start}
 
 

--- a/scripts/broker_upload.py
+++ b/scripts/broker_upload.py
@@ -1,0 +1,12 @@
+"""Stub for uploading trades to a broker API."""
+import logging
+from typing import Iterable
+
+logger = logging.getLogger(__name__)
+
+
+def upload_trades(trades: Iterable[dict]) -> None:
+    """Upload trades to a broker. This is a stub implementation."""
+    logger.info("Uploading %d trades", len(list(trades)))
+    # TODO: integrate with broker SDK/API
+

--- a/scripts/broker_upload.py
+++ b/scripts/broker_upload.py
@@ -7,6 +7,6 @@ logger = logging.getLogger(__name__)
 
 def upload_trades(trades: Iterable[dict]) -> None:
     """Upload trades to a broker. This is a stub implementation."""
-    logger.info("Uploading %d trades", len(list(trades)))
+    logger.info("Uploading %d trades", sum(1 for _ in trades))
     # TODO: integrate with broker SDK/API
 

--- a/scripts/configs/default.json
+++ b/scripts/configs/default.json
@@ -1,0 +1,3 @@
+{
+  "database": "openbb.db"
+}

--- a/scripts/data_pipeline.py
+++ b/scripts/data_pipeline.py
@@ -45,6 +45,8 @@ def preview_data(df: pd.DataFrame, n: int = 5) -> pd.DataFrame:
 if __name__ == "__main__":  # pragma: no cover - manual execution
     cm = ConnectionManager({"database": "openbb.db"})
     prices = fetch_equity("AAPL")
-    print(preview_data(prices))
+    preview = preview_data(prices)
+    for _, row in preview.iterrows():
+        pass  # placeholder for display
     load_prices(prices, cm)
 

--- a/scripts/data_pipeline.py
+++ b/scripts/data_pipeline.py
@@ -30,11 +30,17 @@ def fetch_equity(symbol: str, provider: str = "fmp") -> pd.DataFrame:
 
 
 def load_prices(df: pd.DataFrame, conn_manager: ConnectionManager) -> None:
+    """Load price data into the database with input validation."""
+    required_columns = ["symbol", "date", "open", "high", "low", "close", "volume"]
+    missing_columns = [col for col in required_columns if col not in df.columns]
+    if missing_columns:
+        raise ValueError(f"DataFrame missing required columns: {missing_columns}")
+    
     with conn_manager.context() as conn:
         conn.execute(CREATE_TABLE_SQL)
         conn.executemany(
             INSERT_SQL,
-            df[["symbol", "date", "open", "high", "low", "close", "volume"]].values.tolist(),
+            df[required_columns].values.tolist(),
         )
         conn.commit()
 

--- a/scripts/data_pipeline.py
+++ b/scripts/data_pipeline.py
@@ -2,7 +2,10 @@
 import pandas as pd
 from openbb import obb
 
-from .db_connections import ConnectionManager
+# scripts/data_pipeline.py
+
+-from .db_connections import ConnectionManager
++from scripts.db_connections import ConnectionManager  # absolute import
 
 CREATE_TABLE_SQL = """
 CREATE TABLE IF NOT EXISTS prices (

--- a/scripts/data_pipeline.py
+++ b/scripts/data_pipeline.py
@@ -13,7 +13,8 @@ CREATE TABLE IF NOT EXISTS prices (
     high REAL,
     low REAL,
     close REAL,
-    volume REAL
+    volume REAL,
+    UNIQUE(symbol, date)
 )
 """
 

--- a/scripts/data_pipeline.py
+++ b/scripts/data_pipeline.py
@@ -1,0 +1,50 @@
+"""Data pipeline to fetch prices and load into a database."""
+import pandas as pd
+from openbb import obb
+
+from .db_connections import ConnectionManager
+
+CREATE_TABLE_SQL = """
+CREATE TABLE IF NOT EXISTS prices (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    symbol TEXT NOT NULL,
+    date TEXT NOT NULL,
+    open REAL,
+    high REAL,
+    low REAL,
+    close REAL,
+    volume REAL
+)
+"""
+
+INSERT_SQL = """
+INSERT INTO prices (symbol, date, open, high, low, close, volume)
+VALUES (?, ?, ?, ?, ?, ?, ?)
+"""
+
+
+def fetch_equity(symbol: str, provider: str = "fmp") -> pd.DataFrame:
+    data = obb.equity.price.historical(symbol=symbol, provider=provider)
+    return data.to_dataframe()
+
+
+def load_prices(df: pd.DataFrame, conn_manager: ConnectionManager) -> None:
+    with conn_manager.context() as conn:
+        conn.execute(CREATE_TABLE_SQL)
+        conn.executemany(
+            INSERT_SQL,
+            df[["symbol", "date", "open", "high", "low", "close", "volume"]].values.tolist(),
+        )
+        conn.commit()
+
+
+def preview_data(df: pd.DataFrame, n: int = 5) -> pd.DataFrame:
+    return df.head(n)
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution
+    cm = ConnectionManager({"database": "openbb.db"})
+    prices = fetch_equity("AAPL")
+    print(preview_data(prices))
+    load_prices(prices, cm)
+

--- a/scripts/db_agent.py
+++ b/scripts/db_agent.py
@@ -1,4 +1,5 @@
 """AI assistant for database connection issues using Ollama."""
+# ruff: noqa: S603, S607
 import subprocess
 
 
@@ -13,7 +14,7 @@ def troubleshoot_connection(issue: str, model: str = "openllama") -> str:
         Name of the ollama model to use.
     """
     try:
-        result = subprocess.run(
+        result = subprocess.run(  # noqa: S603,S607
             ["ollama", "run", model, issue],
             check=True,
             capture_output=True,

--- a/scripts/db_agent.py
+++ b/scripts/db_agent.py
@@ -21,6 +21,6 @@ def troubleshoot_connection(issue: str, model: str = "openllama") -> str:
             text=True,
         )
         return result.stdout
-    except Exception as err:  # pragma: no cover - external dependency
+    except (subprocess.CalledProcessError, FileNotFoundError) as err:  # pragma: no cover - external dependency
         return f"Failed to run ollama: {err}"
 

--- a/scripts/db_agent.py
+++ b/scripts/db_agent.py
@@ -1,0 +1,25 @@
+"""AI assistant for database connection issues using Ollama."""
+import subprocess
+
+
+def troubleshoot_connection(issue: str, model: str = "openllama") -> str:
+    """Use Ollama to get help troubleshooting a connection issue.
+
+    Parameters
+    ----------
+    issue: str
+        Description of the connection problem.
+    model: str
+        Name of the ollama model to use.
+    """
+    try:
+        result = subprocess.run(
+            ["ollama", "run", model, issue],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        return result.stdout
+    except Exception as err:  # pragma: no cover - external dependency
+        return f"Failed to run ollama: {err}"
+

--- a/scripts/db_connections.py
+++ b/scripts/db_connections.py
@@ -9,7 +9,7 @@ CONFIG_DIR.mkdir(exist_ok=True)
 
 def list_config_files() -> list[Path]:
     """Return a list of available connection configuration files."""
-    return [p for p in CONFIG_DIR.glob("*.json")]
+    return list(CONFIG_DIR.glob("*.json"))
 
 
 def load_config(name: str) -> dict:

--- a/scripts/db_connections.py
+++ b/scripts/db_connections.py
@@ -1,0 +1,49 @@
+import json
+import sqlite3
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Iterator, Optional
+
+CONFIG_DIR = Path(__file__).resolve().parent / "configs"
+CONFIG_DIR.mkdir(exist_ok=True)
+
+def list_config_files() -> list[Path]:
+    """Return a list of available connection configuration files."""
+    return [p for p in CONFIG_DIR.glob("*.json")]
+
+
+def load_config(name: str) -> dict:
+    """Load a configuration file by name (without extension)."""
+    path = CONFIG_DIR / f"{name}.json"
+    if not path.exists():
+        raise FileNotFoundError(f"Config {name} not found")
+    with path.open() as f:
+        return json.load(f)
+
+
+class ConnectionManager:
+    """Manage database connections."""
+
+    def __init__(self, config: Optional[dict] = None):
+        self.config = config or {}
+        self._conn: Optional[sqlite3.Connection] = None
+
+    def connect(self, config: Optional[dict] = None) -> sqlite3.Connection:
+        cfg = config or self.config
+        db_path = cfg.get("database", "openbb.db")
+        self._conn = sqlite3.connect(db_path)
+        return self._conn
+
+    def close(self) -> None:
+        if self._conn:
+            self._conn.close()
+            self._conn = None
+
+    @contextmanager
+    def context(self, config: Optional[dict] = None) -> Iterator[sqlite3.Connection]:
+        conn = self.connect(config)
+        try:
+            yield conn
+        finally:
+            self.close()
+

--- a/scripts/db_connections.py
+++ b/scripts/db_connections.py
@@ -21,7 +21,22 @@ def load_config(name: str) -> dict:
         return json.load(f)
 
 
+Drop the manual `_conn` state and `close()` in favor of sqlite3’s built-in context manager. This halves the code and removes error-prone state. For example:
+
+```python
+from contextlib import contextmanager
+
 class ConnectionManager:
+    def __init__(self, config: Optional[dict] = None):
+        self.config = config or {}
+
+    @contextmanager
+    def connection(self, config: Optional[dict] = None) -> Iterator[sqlite3.Connection]:
+        cfg = config or self.config
+        db_path = cfg.get("database", "openbb.db")
+        # sqlite3.connect already cleans up on exit
+        with sqlite3.connect(db_path) as conn:
+            yield conn
     """Manage database connections."""
 
     def __init__(self, config: Optional[dict] = None):

--- a/scripts/db_connections.py
+++ b/scripts/db_connections.py
@@ -32,6 +32,7 @@ class ConnectionManager:
         cfg = config or self.config
         db_path = cfg.get("database", "openbb.db")
         self._conn = sqlite3.connect(db_path)
+        self._conn.row_factory = sqlite3.Row
         return self._conn
 
     def close(self) -> None:

--- a/scripts/gui.py
+++ b/scripts/gui.py
@@ -1,0 +1,82 @@
+"""Streamlit GUI for strategy management and backtesting."""
+from __future__ import annotations
+
+import streamlit as st
+
+from .backtesting_agent import run_strategy_backtest
+from .data_pipeline import fetch_equity
+from .db_connections import ConnectionManager
+from .trading_db import (
+    add_rule,
+    add_strategy,
+    initialize_db,
+    list_backtests,
+    list_rules,
+    list_strategies,
+)
+
+st.set_page_config(page_title="OpenBB Strategy Lab", layout="wide")
+
+cm = ConnectionManager({"database": "openbb.db"})
+initialize_db(cm)
+
+
+def tab_data():
+    st.header("Price Data & Backtesting")
+    symbol = st.text_input("Symbol", "AAPL")
+    provider = st.text_input("Provider", "fmp")
+    if st.button("Fetch Data"):
+        data = fetch_equity(symbol, provider)
+        st.line_chart(data.set_index("date")["close"])
+        strategies = list_strategies(cm)
+        if strategies:
+            strategy_names = {s["name"]: s["id"] for s in strategies}
+            selected_name = st.selectbox("Strategy", list(strategy_names))
+            if st.button("Run Backtest"):
+                result = run_strategy_backtest(strategy_names[selected_name], data, cm)
+                st.write("Result", result)
+
+
+def tab_rules():
+    st.header("Manage Trading Rules")
+    name = st.text_input("Rule Name")
+    definition = st.text_area("Definition")
+    if st.button("Add Rule") and name and definition:
+        add_rule(name, definition, cm)
+    st.subheader("Existing Rules")
+    for rule in list_rules(cm):
+        st.write(rule)
+
+
+def tab_strategies():
+    st.header("Strategies")
+    strategies = list_strategies(cm)
+    rules = list_rules(cm)
+    rule_map = {r["name"]: r["id"] for r in rules}
+    name = st.text_input("Strategy Name")
+    selected = st.multiselect("Rules", list(rule_map))
+    if st.button("Add Strategy") and name and selected:
+        add_strategy(name, [rule_map[r] for r in selected], cm)
+    st.subheader("Existing Strategies")
+    for strat in strategies:
+        rule_names = [r for r, _id in rule_map.items() if _id in strat["rule_ids"]]
+        st.write(strat["name"], rule_names)
+
+
+def tab_results():
+    st.header("Backtest Results")
+    for record in list_backtests(cm):
+        st.write(record)
+
+
+tabs = {
+    "Data": tab_data,
+    "Rules": tab_rules,
+    "Strategies": tab_strategies,
+    "Results": tab_results,
+}
+
+selected = st.sidebar.selectbox("View", list(tabs))
+
+with st.container():
+    tabs[selected]()

--- a/scripts/trading_db.py
+++ b/scripts/trading_db.py
@@ -1,0 +1,114 @@
+"""Utilities for storing trading rules and strategies."""
+import json
+from typing import Any, List, Sequence
+
+from .db_connections import ConnectionManager
+
+CREATE_RULES_SQL = """
+CREATE TABLE IF NOT EXISTS rules (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    name TEXT NOT NULL,
+    definition TEXT NOT NULL
+)
+"""
+
+CREATE_STRATEGIES_SQL = """
+CREATE TABLE IF NOT EXISTS strategies (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    name TEXT NOT NULL,
+    rule_ids TEXT NOT NULL
+)
+"""
+
+CREATE_BACKTESTS_SQL = """
+CREATE TABLE IF NOT EXISTS backtests (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    strategy_id INTEGER NOT NULL,
+    start_date TEXT,
+    end_date TEXT,
+    result TEXT NOT NULL,
+    FOREIGN KEY(strategy_id) REFERENCES strategies(id)
+)
+"""
+
+
+def initialize_db(conn_manager: ConnectionManager) -> None:
+    """Create tables for trading rules and strategies."""
+    with conn_manager.context() as conn:
+        conn.execute(CREATE_RULES_SQL)
+        conn.execute(CREATE_STRATEGIES_SQL)
+        conn.execute(CREATE_BACKTESTS_SQL)
+        conn.commit()
+
+
+def add_rule(name: str, definition: str, conn_manager: ConnectionManager) -> int:
+    """Insert a trading rule and return its ID."""
+    with conn_manager.context() as conn:
+        cur = conn.execute(
+            "INSERT INTO rules (name, definition) VALUES (?, ?)",
+            (name, definition),
+        )
+        conn.commit()
+        return int(cur.lastrowid)
+
+
+def list_rules(conn_manager: ConnectionManager) -> List[dict]:
+    """Return all rules."""
+    with conn_manager.context() as conn:
+        cur = conn.execute("SELECT id, name, definition FROM rules")
+        return [dict(row) for row in cur.fetchall()]
+
+
+def add_strategy(name: str, rule_ids: Sequence[int], conn_manager: ConnectionManager) -> int:
+    """Insert a strategy composed of rule IDs."""
+    with conn_manager.context() as conn:
+        cur = conn.execute(
+            "INSERT INTO strategies (name, rule_ids) VALUES (?, ?)",
+            (name, json.dumps(list(rule_ids))),
+        )
+        conn.commit()
+        return int(cur.lastrowid)
+
+
+def list_strategies(conn_manager: ConnectionManager) -> List[dict]:
+    """Return all strategies."""
+    with conn_manager.context() as conn:
+        cur = conn.execute("SELECT id, name, rule_ids FROM strategies")
+        rows = cur.fetchall()
+        return [dict(id=row[0], name=row[1], rule_ids=json.loads(row[2])) for row in rows]
+
+
+def record_backtest(
+    strategy_id: int,
+    start_date: str,
+    end_date: str,
+    result: Any,
+    conn_manager: ConnectionManager,
+) -> int:
+    """Record backtest results."""
+    with conn_manager.context() as conn:
+        cur = conn.execute(
+            "INSERT INTO backtests (strategy_id, start_date, end_date, result) VALUES (?, ?, ?, ?)",
+            (strategy_id, start_date, end_date, json.dumps(result)),
+        )
+        conn.commit()
+        return int(cur.lastrowid)
+
+
+def list_backtests(conn_manager: ConnectionManager) -> List[dict]:
+    """Return all backtest records."""
+    with conn_manager.context() as conn:
+        cur = conn.execute(
+            "SELECT id, strategy_id, start_date, end_date, result FROM backtests"
+        )
+        rows = cur.fetchall()
+        return [
+            {
+                "id": row[0],
+                "strategy_id": row[1],
+                "start_date": row[2],
+                "end_date": row[3],
+                "result": json.loads(row[4]),
+            }
+            for row in rows
+        ]

--- a/scripts/trading_db.py
+++ b/scripts/trading_db.py
@@ -61,6 +61,18 @@ def list_rules(conn_manager: ConnectionManager) -> List[dict]:
 
 def add_strategy(name: str, rule_ids: Sequence[int], conn_manager: ConnectionManager) -> int:
     """Insert a strategy composed of rule IDs."""
+    # Verify all rule IDs exist
+    with conn_manager.context() as conn:
+        qs = ",".join("?" * len(rule_ids))
+        cur = conn.execute(
+            f"SELECT id FROM rules WHERE id IN ({qs})",
+            tuple(rule_ids),
+        )
+        found_ids = {row["id"] for row in cur.fetchall()}
+        missing = set(rule_ids) - found_ids
+        if missing:
+            raise ValueError(f"Unknown rule IDs: {sorted(missing)}")
+
     with conn_manager.context() as conn:
         cur = conn.execute(
             "INSERT INTO strategies (name, rule_ids) VALUES (?, ?)",


### PR DESCRIPTION
## Summary
- add scripts for DB connections and pipelines
- include placeholders for broker upload and backtesting
- document setup in REPORT.md

## Testing
- `ruff check scripts`
- `pytest -q openbb_platform/tests`

------
https://chatgpt.com/codex/tasks/task_e_684afe1af020832a96d225d260d6f779

## Summary by Sourcery

Introduce a basic database pipeline and utility scripts, including connection management, data fetching and loading, AI-assisted troubleshooting, and placeholders for broker uploads and backtesting, along with documentation.

New Features:
- Provide a ConnectionManager for managing SQLite connections with configurable JSON files
- Implement a data pipeline to fetch historical equity prices, preview them, and load into a SQLite database
- Add a db_agent script that uses Ollama to troubleshoot database connection issues
- Add stub scripts for broker trade uploads and a backtesting agent calculating buy-and-hold returns
- Include default JSON config and utilities to list and load connection configurations

Documentation:
- Add REPORT.md documenting the new scripts, pipeline setup, and configuration process

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced scripts for managing database connections, retrieving and previewing financial data, uploading trades, and running basic backtesting.
  - Added a Streamlit GUI for managing trading rules, strategies, and backtesting workflows.
  - Provided database utilities for handling trading rules, strategies, and backtest records.
  - Added a configuration file for database settings.
  - Provided a markdown report summarizing the functionality of the new scripts.

- **Documentation**
  - Added a report file outlining the features and workflows of the newly introduced scripts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->