### PR TITLE
Add realtime price API and web viewer

### DIFF
--- a/DIFF_20250623_192254.md
+++ b/DIFF_20250623_192254.md
@@ -1,0 +1,6 @@
+### Diff 2025-06-23 19:22:54 UTC
+- Added realtime price API router with endpoints to fetch and store quotes
+- Added SQLAlchemy models and dependencies for PostgreSQL
+- Mounted new webapp static directory and created simple frontend
+- Updated REST API to include realtime router
+- Updated pyproject dependencies for yfinance and database packages

--- a/RECOMMENDATIONS_20250623_192254.md
+++ b/RECOMMENDATIONS_20250623_192254.md
@@ -1,0 +1,4 @@
+### Recommendations 2025-06-23 19:22:54 UTC
+- Implement authentication and rate limiting for the realtime API
+- Add unit tests for database interactions and API routes
+- Extend the frontend with charts using Plotly or other libraries

--- a/openbb_platform/core/openbb_core/api/rest_api.py
+++ b/openbb_platform/core/openbb_core/api/rest_api.py
@@ -5,10 +5,12 @@ from contextlib import asynccontextmanager
 
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.staticfiles import StaticFiles
 from openbb_core.api.app_loader import AppLoader
 from openbb_core.api.router.commands import router as router_commands
 from openbb_core.api.router.coverage import router as router_coverage
 from openbb_core.api.router.system import router as router_system
+from openbb_core.api.router.realtime_price import router as router_realtime
 from openbb_core.app.service.auth_service import AuthService
 from openbb_core.app.service.system_service import SystemService
 from openbb_core.env import Env
@@ -71,15 +73,22 @@ app.add_middleware(
     allow_methods=system.api_settings.cors.allow_methods,
     allow_headers=system.api_settings.cors.allow_headers,
 )
+app.mount("/", StaticFiles(directory="webapp", html=True), name="webapp")
 AppLoader.add_routers(
     app=app,
     routers=(
-        [AuthService().router, router_system, router_coverage, router_commands]
+        [
+            AuthService().router,
+            router_system,
+            router_coverage,
+            router_commands,
+            router_realtime,
+        ]
         if Env().DEV_MODE
         else (
-            [router_commands, router_coverage]
+            [router_commands, router_coverage, router_realtime]
             if hasattr(router_commands, "routes") and router_commands.routes
-            else [router_commands]
+            else [router_commands, router_realtime]
         )
     ),
     prefix=system.api_settings.prefix,

--- a/openbb_platform/core/openbb_core/api/router/realtime_price.py
+++ b/openbb_platform/core/openbb_core/api/router/realtime_price.py
@@ -1,0 +1,81 @@
+"""Realtime price data router."""
+
+from __future__ import annotations
+
+import os
+from datetime import datetime
+from typing import List
+
+import yfinance as yf
+from fastapi import APIRouter
+from pydantic import BaseModel
+from sqlalchemy import Column, DateTime, Float, Integer, String, create_engine
+from sqlalchemy.orm import declarative_base, sessionmaker
+
+DATABASE_URL = os.getenv(
+    "DATABASE_URL",
+    "postgresql://postgres:postgres@localhost:5432/postgres",
+)
+
+engine = create_engine(DATABASE_URL)
+SessionLocal = sessionmaker(bind=engine)
+Base = declarative_base()
+
+
+class Price(Base):
+    """Database model for price data."""
+
+    __tablename__ = "prices"
+
+    id = Column(Integer, primary_key=True)
+    symbol = Column(String, index=True)
+    price = Column(Float)
+    timestamp = Column(DateTime, default=datetime.utcnow)
+
+
+Base.metadata.create_all(bind=engine)
+
+
+class PriceResponse(BaseModel):
+    """Response model for price data."""
+
+    symbol: str
+    price: float
+    timestamp: datetime
+
+
+router = APIRouter(prefix="/realtime", tags=["Realtime Price"])
+
+
+@router.get("/{symbol}", response_model=PriceResponse)
+async def get_price(symbol: str) -> PriceResponse:
+    """Fetch realtime price without storing it."""
+    ticker = yf.Ticker(symbol)
+    price = ticker.fast_info["last_price"]
+    timestamp = datetime.utcnow()
+    return PriceResponse(symbol=symbol, price=price, timestamp=timestamp)
+
+
+@router.post("/{symbol}", response_model=PriceResponse)
+async def fetch_and_store(symbol: str) -> PriceResponse:
+    """Fetch realtime price and store it in the database."""
+    ticker = yf.Ticker(symbol)
+    price = ticker.fast_info["last_price"]
+    timestamp = datetime.utcnow()
+    db = SessionLocal()
+    db.add(Price(symbol=symbol, price=price, timestamp=timestamp))
+    db.commit()
+    db.close()
+    return PriceResponse(symbol=symbol, price=price, timestamp=timestamp)
+
+
+@router.get("/stored", response_model=List[PriceResponse])
+async def get_stored(limit: int = 100) -> List[PriceResponse]:
+    """Retrieve stored prices from the database."""
+    db = SessionLocal()
+    results = db.query(Price).order_by(Price.timestamp.desc()).limit(limit).all()
+    db.close()
+    return [
+        PriceResponse(symbol=r.symbol, price=r.price, timestamp=r.timestamp)
+        for r in results
+    ]

--- a/openbb_platform/core/pyproject.toml
+++ b/openbb_platform/core/pyproject.toml
@@ -22,8 +22,11 @@ requests = "^2.32.1"
 importlib-metadata = ">=6.8.0"
 python-dotenv = "^1.0.0"
 aiohttp = "^3.11.11"
+sqlalchemy = "^2.0"
+psycopg2-binary = "^2.9"
 ruff = "^0.7"              # Needed here to lint generated code
 pyjwt = "^2.10.1"
+yfinance = "^0.2"
 
 [tool.poetry.scripts]
 openbb-build = "openbb_core.build:main"

--- a/webapp/index.html
+++ b/webapp/index.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Realtime Price Viewer</title>
+  <script>
+    async function fetchPrice() {
+      const symbol = document.getElementById('symbol').value;
+      const res = await fetch(`/realtime/${symbol}`);
+      const data = await res.json();
+      document.getElementById('price').textContent =
+        `Symbol: ${data.symbol} Price: ${data.price} Timestamp: ${data.timestamp}`;
+    }
+  </script>
+</head>
+<body>
+  <h1>Realtime Price Viewer</h1>
+  <input id="symbol" value="AAPL" />
+  <button onclick="fetchPrice()">Fetch Price</button>
+  <p id="price"></p>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- provide FastAPI router `/realtime` for fetching and storing stock prices using yfinance
- mount a minimal webapp to call the realtime endpoint
- include router in REST API and serve static files
- add SQLAlchemy and postgres dependencies

## Testing
- `ruff check openbb_platform/core/openbb_core/api/router/realtime_price.py`
- `pytest -q` *(fails: 40 errors)*

------
https://chatgpt.com/codex/tasks/task_e_6859a82815a4832a9d998e6a8b76facc

## Summary by Sourcery

Add a realtime stock price API with endpoints to fetch and persist quotes, mount a minimal web interface for on-demand price queries, and update project dependencies accordingly.

New Features:
- Expose GET and POST /realtime/{symbol} endpoints to retrieve and store live stock prices and GET /realtime/stored to list saved quotes
- Serve a basic single-page web viewer where users can enter a symbol and fetch realtime prices

Enhancements:
- Integrate yfinance for price retrieval and SQLAlchemy with PostgreSQL for data persistence
- Mount the `webapp` directory as a static files endpoint and register the realtime router in the FastAPI app

Build:
- Add SQLAlchemy, psycopg2-binary, and yfinance to project dependencies

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced realtime price API endpoints for fetching and storing financial quotes.
	- Added persistent storage of price data using a PostgreSQL database.
	- Launched a simple web interface for viewing realtime prices directly in the browser.
- **Chores**
	- Updated dependencies to support database interaction and financial data retrieval.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->