### PR TITLE
Add RAG knowledge base

### DIFF
--- a/DIFF_20250630_211016.md
+++ b/DIFF_20250630_211016.md
@@ -1,0 +1,6 @@
+### Diff 2025-06-30 21:10:16 UTC
+- Added RAG knowledge base router using Langchain and Chroma
+- Introduced new web page `rag.html` for interacting with the knowledge base
+- Updated REST API to mount `router_rag`
+- Added example document in `knowledge_base/docs`
+- Documented new feature in README

--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ If you are looking for our **FREE** AI-powered Research and Analytics Workspace,
 
 We also have an open source AI financial analyst agent that can access all of the data within OpenBB, and that repo can be found [here](https://github.com/OpenBB-finance/openbb-agents).
 
+The platform now includes a simple Knowledge Base with Retrieval-Augmented Generation (RAG) capabilities.  Documents can be ingested via `/rag/ingest` and queried using `/rag/query`.  A minimal web interface is available at [`rag.html`](webapp/rag.html).
+
 ---
 
 <!-- TABLE OF CONTENTS -->

--- a/RECOMMENDATIONS_20250630_211016.md
+++ b/RECOMMENDATIONS_20250630_211016.md
@@ -1,0 +1,4 @@
+### Recommendations 2025-06-30 21:10:16 UTC
+- Expand vector DB support to Weaviate, Elasticsearch, and Pinecone
+- Add authentication and history tracking for RAG queries
+- Provide UI styling consistent with existing components

--- a/knowledge_base/docs/intro.txt
+++ b/knowledge_base/docs/intro.txt
@@ -1,0 +1,1 @@
+OpenBB is an open-source investment research platform.

--- a/openbb_platform/core/openbb_core/api/rest_api.py
+++ b/openbb_platform/core/openbb_core/api/rest_api.py
@@ -9,8 +9,9 @@ from fastapi.staticfiles import StaticFiles
 from openbb_core.api.app_loader import AppLoader
 from openbb_core.api.router.commands import router as router_commands
 from openbb_core.api.router.coverage import router as router_coverage
-from openbb_core.api.router.system import router as router_system
+from openbb_core.api.router.rag import router as router_rag
 from openbb_core.api.router.realtime_price import router as router_realtime
+from openbb_core.api.router.system import router as router_system
 from openbb_core.app.service.auth_service import AuthService
 from openbb_core.app.service.system_service import SystemService
 from openbb_core.env import Env
@@ -83,12 +84,13 @@ AppLoader.add_routers(
             router_coverage,
             router_commands,
             router_realtime,
+            router_rag,
         ]
         if Env().DEV_MODE
         else (
-            [router_commands, router_coverage, router_realtime]
+            [router_commands, router_coverage, router_realtime, router_rag]
             if hasattr(router_commands, "routes") and router_commands.routes
-            else [router_commands, router_realtime]
+            else [router_commands, router_realtime, router_rag]
         )
     ),
     prefix=system.api_settings.prefix,

--- a/openbb_platform/core/openbb_core/api/router/rag.py
+++ b/openbb_platform/core/openbb_core/api/router/rag.py
@@ -1,0 +1,55 @@
+"""RAG knowledge base router."""
+
+from __future__ import annotations
+
+import glob
+import os
+from typing import List
+
+from fastapi import APIRouter
+from langchain.docstore.document import Document
+from langchain.embeddings import HuggingFaceEmbeddings
+from langchain.text_splitter import RecursiveCharacterTextSplitter
+from langchain.vectorstores import Chroma
+from pydantic import BaseModel
+
+router = APIRouter(prefix="/rag", tags=["RAG"])
+
+DB_DIR = os.getenv("RAG_DB", "rag_db")
+EMBED_MODEL = os.getenv("EMBED_MODEL", "sentence-transformers/all-MiniLM-L6-v2")
+
+embeddings = HuggingFaceEmbeddings(model_name=EMBED_MODEL)
+vector_db = Chroma(persist_directory=DB_DIR, embedding_function=embeddings)
+
+
+def load_docs(directory: str) -> List[Document]:
+    docs: List[Document] = []
+    for path in glob.glob(os.path.join(directory, "*.txt")):
+        with open(path, encoding="utf-8") as f:
+            docs.append(Document(page_content=f.read()))
+    return docs
+
+
+@router.post("/ingest")
+def ingest() -> dict:
+    """Ingest documents from the knowledge base directory."""
+    docs = load_docs("knowledge_base/docs")
+    splitter = RecursiveCharacterTextSplitter(chunk_size=500, chunk_overlap=50)
+    chunks = splitter.split_documents(docs)
+    if chunks:
+        vector_db.add_documents(chunks)
+        vector_db.persist()
+    return {"ingested": len(chunks)}
+
+
+class Query(BaseModel):
+    question: str
+
+
+@router.post("/query")
+def query_rag(q: Query) -> dict:
+    """Query the knowledge base."""
+    retriever = vector_db.as_retriever()
+    results = retriever.get_relevant_documents(q.question)
+    answer = " ".join(r.page_content for r in results[:3])
+    return {"answer": answer, "sources": len(results)}

--- a/openbb_platform/core/openbb_core/api/router/rag.py
+++ b/openbb_platform/core/openbb_core/api/router/rag.py
@@ -22,12 +22,19 @@ embeddings = HuggingFaceEmbeddings(model_name=EMBED_MODEL)
 vector_db = Chroma(persist_directory=DB_DIR, embedding_function=embeddings)
 
 
-def load_docs(directory: str) -> List[Document]:
-    docs: List[Document] = []
-    for path in glob.glob(os.path.join(directory, "*.txt")):
-        with open(path, encoding="utf-8") as f:
-            docs.append(Document(page_content=f.read()))
-    return docs
++import logging
++
++
++def load_docs(directory: str) -> List[Document]:
++    logger = logging.getLogger(__name__)
++    docs: List[Document] = []
++    for path in glob.glob(os.path.join(directory, "*.txt")):
++        try:
++            with open(path, encoding="utf-8") as f:
++                docs.append(Document(page_content=f.read()))
++        except Exception as e:
++            logger.warning(f"Could not read file {path}: {e}")
++    return docs
 
 
 @router.post("/ingest")

--- a/openbb_platform/core/openbb_core/api/router/rag.py
+++ b/openbb_platform/core/openbb_core/api/router/rag.py
@@ -33,7 +33,7 @@ def load_docs(directory: str) -> List[Document]:
 @router.post("/ingest")
 def ingest() -> dict:
     """Ingest documents from the knowledge base directory."""
-    docs = load_docs("knowledge_base/docs")
+    docs = load_docs(KNOWLEDGE_BASE_DIR)
     splitter = RecursiveCharacterTextSplitter(chunk_size=500, chunk_overlap=50)
     chunks = splitter.split_documents(docs)
     if chunks:

--- a/webapp/rag.html
+++ b/webapp/rag.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Knowledge Base Chat</title>
+  <script>
+    async function ingest() {
+      const res = await fetch('/rag/ingest', {method: 'POST'});
+      const data = await res.json();
+      document.getElementById('status').textContent = JSON.stringify(data);
+    }
+    async function ask() {
+      const question = document.getElementById('question').value;
+      const res = await fetch('/rag/query', {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify({question})
+      });
+      const data = await res.json();
+      document.getElementById('answer').textContent = data.answer;
+    }
+  </script>
+</head>
+<body>
+  <h1>Knowledge Base Q&A</h1>
+  <button onclick="ingest()">Ingest Docs</button><br/>
+  <input id="question" placeholder="Ask a question" style="width:80%;" />
+  <button onclick="ask()">Ask</button>
+  <p id="status"></p>
+  <pre id="answer"></pre>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create a simple RAG router using Langchain and Chroma
- expose new endpoints via REST API
- add a minimal web page to interact with the RAG database
- document feature in README
- record diff and recommendations

## Testing
- `ruff check .` *(fails: many issues)*
- `pytest -k rag -q` *(fails: ModuleNotFoundError: No module named 'openbb_core')*

------
https://chatgpt.com/codex/tasks/task_e_6862fc5a6400832a9e899d1842284970

## Summary by Sourcery

Add a simple RAG knowledge base using Langchain and Chroma, expose ingestion and query endpoints via the REST API, provide a basic web UI, include sample documents, and document the feature in the README.

New Features:
- Introduce a Retrieval-Augmented Generation (RAG) router with `/rag/ingest` and `/rag/query` endpoints
- Provide a minimal web interface (`rag.html`) for ingesting documents and querying the RAG knowledge base
- Include sample documents in `knowledge_base/docs` for ingestion

Enhancements:
- Integrate the RAG router into the existing REST API routing configuration

Documentation:
- Add README entries describing the RAG knowledge base endpoints and web UI

Chores:
- Add diff and recommendations markdown logs for the RAG feature