### PR TITLE
Add news aggregation endpoint and examples

### DIFF
--- a/DIFF_20250701_011432.md
+++ b/DIFF_20250701_011432.md
@@ -1,0 +1,5 @@
+### Diff 2025-07-01 01:14:32 UTC
+- Added Biztoc news router with latest endpoint
+- Included news router in REST API
+- Created webapp/news.html for real-time news aggregation
+- Added example news and price scripts

--- a/NOTES_20250701_011432.md
+++ b/NOTES_20250701_011432.md
@@ -1,0 +1,9 @@
+### Notes 2025-07-01 01:14:32 UTC
+Potential embedding models for sentiment and news analysis:
+- `sentence-transformers/all-MiniLM-L6-v2` for general embeddings
+- `FinBERT` (via Hugging Face `ProsusAI/finbert`) for financial sentiment
+- `OpenAI` models if available for high quality embeddings
+News APIs worth exploring:
+- Biztoc (RapidAPI)
+- Benzinga (requires key)
+- FMP and Intrinio for company-specific news

--- a/RECOMMENDATIONS_20250701_011432.md
+++ b/RECOMMENDATIONS_20250701_011432.md
@@ -1,0 +1,4 @@
+### Recommendations 2025-07-01 01:14:32 UTC
+- Consider caching news results to reduce API usage
+- Provide authentication guards for the new news endpoint
+- Add unit tests for news router and frontend scripts

--- a/THOUGHTS.md
+++ b/THOUGHTS.md
@@ -1,0 +1,2 @@
+### Thoughts 2025-07-01
+Adding a news router allows the platform to ingest articles directly via the REST API. Once credentials are configured, it should stream data into existing pipelines for further analysis. Integrating websocket streaming from Twitter would be a logical next step, but it requires API keys that cannot be provisioned here.

--- a/openbb_platform/core/openbb_core/api/rest_api.py
+++ b/openbb_platform/core/openbb_core/api/rest_api.py
@@ -9,6 +9,7 @@ from fastapi.staticfiles import StaticFiles
 from openbb_core.api.app_loader import AppLoader
 from openbb_core.api.router.commands import router as router_commands
 from openbb_core.api.router.coverage import router as router_coverage
+from openbb_core.api.router.news import router as router_news
 from openbb_core.api.router.realtime_price import router as router_realtime
 from openbb_core.api.router.research import router as router_research
 from openbb_core.api.router.system import router as router_system
@@ -85,12 +86,13 @@ AppLoader.add_routers(
             router_commands,
             router_realtime,
             router_research,
+            router_news,
         ]
         if Env().DEV_MODE
         else (
-            [router_commands, router_coverage, router_realtime, router_research]
+            [router_commands, router_coverage, router_realtime, router_research, router_news]
             if hasattr(router_commands, "routes") and router_commands.routes
-            else [router_commands, router_realtime, router_research]
+            else [router_commands, router_realtime, router_research, router_news]
         )
     ),
     prefix=system.api_settings.prefix,

--- a/openbb_platform/core/openbb_core/api/router/news.py
+++ b/openbb_platform/core/openbb_core/api/router/news.py
@@ -1,0 +1,31 @@
+"""News router for fetching latest articles."""
+
+from __future__ import annotations
+
+from typing import List
+
+from fastapi import APIRouter, HTTPException
+from openbb_biztoc.models.world_news import BiztocWorldNewsFetcher
+from openbb_core.app.service.user_service import UserService
+
+router = APIRouter(prefix="/news", tags=["News"])
+
+
+def _credentials() -> dict:
+    """Return user credentials from settings."""
+    return UserService().default_user_settings.credentials.model_dump(mode="json")
+
+
+@router.get("/latest", response_model=List[dict])
+async def get_latest_news(
+    term: str | None = None,
+    source: str | None = None,
+    limit: int = 10,
+) -> List[dict]:
+    """Fetch latest news articles."""
+    params = {"term": term, "source": source, "limit": limit}
+    try:
+        data = await BiztocWorldNewsFetcher.fetch_data(params=params, credentials=_credentials())
+        return [item.model_dump() for item in data]
+    except Exception as err:  # pragma: no cover - simple handler
+        raise HTTPException(status_code=500, detail=str(err)) from err

--- a/scripts/news_pipeline.py
+++ b/scripts/news_pipeline.py
@@ -1,0 +1,23 @@
+"""Example script to fetch free news data using the Biztoc API."""
+
+from __future__ import annotations
+
+from openbb_biztoc.models.world_news import BiztocWorldNewsFetcher
+from openbb_core.app.service.user_service import UserService
+
+
+def get_credentials() -> dict:
+    """Return stored credentials."""
+    return UserService().default_user_settings.credentials.model_dump(mode="json")
+
+
+def latest_news(limit: int = 10):
+    """Fetch latest news articles."""
+    params = {"limit": limit}
+    data = BiztocWorldNewsFetcher.fetch_data(params=params, credentials=get_credentials())
+    return data
+
+
+if __name__ == "__main__":
+    for article in latest_news(5):
+        print(article.title, "-", article.source)  # noqa: T201

--- a/scripts/price_example.py
+++ b/scripts/price_example.py
@@ -7,10 +7,16 @@ from datetime import datetime
 import yfinance as yf
 
 
-def get_price(symbol: str):
+def get_price(symbol: str) -> tuple[float, datetime]:
     """Return latest price and timestamp for a symbol."""
-    ticker = yf.Ticker(symbol)
-    return ticker.fast_info["last_price"], datetime.utcnow()
+    try:
+        ticker = yf.Ticker(symbol)
+        price = ticker.fast_info["last_price"]
+        if price is None:
+            raise ValueError(f"No price data available for symbol: {symbol}")
+        return price, datetime.now(timezone.utc)
+    except Exception as e:
+        raise ValueError(f"Failed to fetch price for {symbol}: {e}") from e
 
 
 if __name__ == "__main__":

--- a/scripts/price_example.py
+++ b/scripts/price_example.py
@@ -1,0 +1,18 @@
+"""Sample script for fetching realtime prices using yfinance."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+import yfinance as yf
+
+
+def get_price(symbol: str):
+    """Return latest price and timestamp for a symbol."""
+    ticker = yf.Ticker(symbol)
+    return ticker.fast_info["last_price"], datetime.utcnow()
+
+
+if __name__ == "__main__":
+    price, ts = get_price("AAPL")
+    print("AAPL", price, ts.isoformat())  # noqa: T201

--- a/webapp/news.html
+++ b/webapp/news.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>News Wire Aggregator</title>
+  <style>
+    body { font-family: Arial, sans-serif; }
+    #news-list { width: 100%; border-collapse: collapse; }
+    #news-list th, #news-list td { border: 1px solid #ccc; padding: 4px; }
+    #news-list th { background-color: #f0f0f0; }
+    #news-list td.title { width: 70%; }
+  </style>
+  <script>
+    async function fetchNews() {
+      const res = await fetch('/news/latest?limit=20');
+      const data = await res.json();
+      const tbody = document.getElementById('news-body');
+      tbody.innerHTML = '';
+      data.forEach(item => {
+        const row = document.createElement('tr');
+        const title = document.createElement('td');
+        title.className = 'title';
+        title.textContent = item.title;
+        const info = document.createElement('td');
+        info.textContent = `${item.source || ''} ${item.author || ''}`.trim();
+        row.appendChild(title);
+        row.appendChild(info);
+        tbody.appendChild(row);
+      });
+    }
+
+    setInterval(fetchNews, 60000);
+    window.onload = fetchNews;
+  </script>
+</head>
+<body>
+  <h1>News Wire Aggregator</h1>
+  <table id="news-list">
+    <thead>
+      <tr><th>Headline</th><th>Source / Journalist</th></tr>
+    </thead>
+    <tbody id="news-body"></tbody>
+  </table>
+</body>
+</html>

--- a/webapp/news.html
+++ b/webapp/news.html
@@ -12,21 +12,30 @@
   </style>
   <script>
     async function fetchNews() {
-      const res = await fetch('/news/latest?limit=20');
-      const data = await res.json();
-      const tbody = document.getElementById('news-body');
-      tbody.innerHTML = '';
-      data.forEach(item => {
-        const row = document.createElement('tr');
-        const title = document.createElement('td');
-        title.className = 'title';
-        title.textContent = item.title;
-        const info = document.createElement('td');
-        info.textContent = `${item.source || ''} ${item.author || ''}`.trim();
-        row.appendChild(title);
-        row.appendChild(info);
-        tbody.appendChild(row);
-      });
+      try {
+        const res = await fetch('/news/latest?limit=20');
+        if (!res.ok) {
+          throw new Error(`Failed to fetch news: ${res.status} ${res.statusText}`);
+        }
+        const data = await res.json();
+        const tbody = document.getElementById('news-body');
+        tbody.innerHTML = '';
+        data.forEach(item => {
+          const row = document.createElement('tr');
+          const title = document.createElement('td');
+          title.className = 'title';
+          title.textContent = item.title;
+          const info = document.createElement('td');
+          info.textContent = `${item.source || ''} ${item.author || ''}`.trim();
+          row.appendChild(title);
+          row.appendChild(info);
+          tbody.appendChild(row);
+        });
+      } catch (error) {
+        const tbody = document.getElementById('news-body');
+        tbody.innerHTML = '<tr><td colspan="2">Failed to load news. Please try again later.</td></tr>';
+        console.error('Error fetching news:', error);
+      }
     }
 
     setInterval(fetchNews, 60000);


### PR DESCRIPTION
## Summary
- add Biztoc news router
- expose news router in REST API
- create simple news feed page
- add example scripts for news and realtime prices
- document changes and ideas

## Testing
- `ruff check openbb_platform/core/openbb_core/api/router/news.py scripts/news_pipeline.py scripts/price_example.py`
- `pytest -q` *(fails: ModuleNotFoundError for many provider packages)*

------
https://chatgpt.com/codex/tasks/task_e_686334d45364832aa12f1ab37179643e

## Summary by Sourcery

Introduce a news aggregation feature by adding a Biztoc-backed news endpoint, integrating it into the REST API, providing a simple web interface, example scripts, and accompanying documentation

New Features:
- Implement a /news/latest endpoint to fetch world news through BiztocWorldNewsFetcher with user credentials
- Expose the news router in the REST API at /news/latest
- Add a News Wire Aggregator web page (webapp/news.html) for real-time news display
- Include example scripts for fetching news (news_pipeline.py) and real-time prices (price_example.py)

Documentation:
- Add markdown documentation with project notes, diff history, recommendations, and future enhancement ideas

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a new "latest news" endpoint accessible via the API for real-time news aggregation.
  * Added a web page for users to view and refresh the latest news headlines automatically.
  * Provided example scripts for fetching news articles and real-time stock price data.

* **Documentation**
  * Added notes and recommendations on embedding models, news APIs, caching, authentication, and testing strategies.

* **Chores**
  * Included internal notes and thoughts on the news router and potential future enhancements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->