### PR TITLE
Add portfolio tools and price history API

### DIFF
--- a/DIFF_20250709_061154.md
+++ b/DIFF_20250709_061154.md
@@ -1,0 +1,7 @@
+### Diff 2025-07-09 06:11:54 UTC
+- Added index.html with site navigation and renamed old realtime page to realtime.html
+- Created portfolio performance page using Chart.js
+- Implemented portfolio, historical price routers and registered them in REST API
+- Added caching and authentication to news router
+- Added SQLite data ingestion utilities and backtesting updates
+- Fixed rag router logging and knowledge base path handling

--- a/RECOMMENDATIONS_20250709_061154.md
+++ b/RECOMMENDATIONS_20250709_061154.md
@@ -1,0 +1,4 @@
+### Recommendations 2025-07-09 06:11:54 UTC
+- Add persistent user portfolios and authentication across API routes
+- Expand test coverage for new historical and portfolio modules
+- Consider refactoring database layer to use SQLModel for type safety

--- a/openbb_platform/core/openbb_core/api/rest_api.py
+++ b/openbb_platform/core/openbb_core/api/rest_api.py
@@ -9,8 +9,14 @@ from fastapi.staticfiles import StaticFiles
 from openbb_core.api.app_loader import AppLoader
 from openbb_core.api.router.commands import router as router_commands
 from openbb_core.api.router.coverage import router as router_coverage
-
+from openbb_core.api.router.historical_price import router as router_history
+from openbb_core.api.router.news import router as router_news
+from openbb_core.api.router.portfolio import router as router_portfolio
+from openbb_core.api.router.rag import router as router_rag
+from openbb_core.api.router.realtime_price import router as router_realtime
+from openbb_core.api.router.research import router as router_research
 from openbb_core.api.router.system import router as router_system
+from openbb_core.api.router.user import router as router_user
 from openbb_core.app.service.auth_service import AuthService
 from openbb_core.app.service.system_service import SystemService
 from openbb_core.env import Env
@@ -83,8 +89,13 @@ AppLoader.add_routers(
             router_coverage,
             router_commands,
             router_realtime,
-
-        )
+            router_history,
+            router_portfolio,
+            router_research,
+            router_rag,
+            router_news,
+            router_user,
+        ]
     ),
     prefix=system.api_settings.prefix,
 )

--- a/openbb_platform/core/openbb_core/api/router/historical_price.py
+++ b/openbb_platform/core/openbb_core/api/router/historical_price.py
@@ -1,0 +1,87 @@
+"""Historical price data router."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import List, Optional
+
+import yfinance as yf
+from fastapi import APIRouter, Query
+from pydantic import BaseModel
+from sqlalchemy import Column, Date, Float, Integer, String, create_engine, select
+from sqlalchemy.orm import DeclarativeBase, Session
+
+DATABASE_URL = "sqlite:///historical.db"
+engine = create_engine(DATABASE_URL)
+
+
+class Base(DeclarativeBase):
+    pass
+
+
+class HistoricalPrice(Base):
+    __tablename__ = "historical_prices"
+
+    id = Column(Integer, primary_key=True)
+    symbol = Column(String, index=True)
+    date = Column(Date)
+    open = Column(Float)
+    high = Column(Float)
+    low = Column(Float)
+    close = Column(Float)
+    volume = Column(Float)
+
+
+Base.metadata.create_all(bind=engine)
+
+
+class PriceBar(BaseModel):
+    symbol: str
+    date: datetime
+    open: float
+    high: float
+    low: float
+    close: float
+    volume: float
+
+
+router = APIRouter(prefix="/history", tags=["Historical Price"])
+
+
+@router.get("/{symbol}", response_model=List[PriceBar])
+async def get_history(
+    symbol: str,
+    start: Optional[str] = Query(None),
+    end: Optional[str] = Query(None),
+) -> List[PriceBar]:
+    """Fetch historical prices and store in the database."""
+    df = yf.download(symbol, start=start, end=end, progress=False)
+    df.reset_index(inplace=True)
+    with Session(engine) as session:
+        for _, row in df.iterrows():
+            session.merge(
+                HistoricalPrice(
+                    symbol=symbol,
+                    date=row["Date"].date(),
+                    open=row["Open"],
+                    high=row["High"],
+                    low=row["Low"],
+                    close=row["Close"],
+                    volume=row["Volume"],
+                )
+            )
+        session.commit()
+        stmt = select(HistoricalPrice).where(HistoricalPrice.symbol == symbol).order_by(HistoricalPrice.date.desc())
+        rows = session.execute(stmt).scalars().all()
+    return [
+        PriceBar(
+            symbol=r.symbol,
+            date=datetime.combine(r.date, datetime.min.time()),
+            open=r.open,
+            high=r.high,
+            low=r.low,
+            close=r.close,
+            volume=r.volume,
+        )
+        for r in rows
+    ]

--- a/openbb_platform/core/openbb_core/api/router/news.py
+++ b/openbb_platform/core/openbb_core/api/router/news.py
@@ -2,13 +2,18 @@
 
 from __future__ import annotations
 
+import time
 from typing import List
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, Depends, HTTPException
 from openbb_biztoc.models.world_news import BiztocWorldNewsFetcher
+from openbb_core.app.service.auth_service import AuthService
 from openbb_core.app.service.user_service import UserService
 
 router = APIRouter(prefix="/news", tags=["News"])
+auth_hook = AuthService().auth_hook
+
+_cache: dict[str, tuple[float, list[dict]]] = {}
 
 
 def _credentials() -> dict:
@@ -21,11 +26,18 @@ async def get_latest_news(
     term: str | None = None,
     source: str | None = None,
     limit: int = 10,
+    _: None = Depends(auth_hook),
 ) -> List[dict]:
-    """Fetch latest news articles."""
+    """Fetch latest news articles with simple caching."""
+    key = f"{term}-{source}-{limit}"
+    ts, cached = _cache.get(key, (0.0, []))
+    if time.time() - ts < 300 and cached:
+        return cached
     params = {"term": term, "source": source, "limit": limit}
     try:
         data = await BiztocWorldNewsFetcher.fetch_data(params=params, credentials=_credentials())
-        return [item.model_dump() for item in data]
+        items = [item.model_dump() for item in data]
+        _cache[key] = (time.time(), items)
+        return items
     except Exception as err:  # pragma: no cover - simple handler
         raise HTTPException(status_code=500, detail=str(err)) from err

--- a/openbb_platform/core/openbb_core/api/router/portfolio.py
+++ b/openbb_platform/core/openbb_core/api/router/portfolio.py
@@ -1,0 +1,27 @@
+"""Portfolio performance router."""
+
+from __future__ import annotations
+
+from datetime import date, timedelta
+from typing import List
+
+from fastapi import APIRouter
+from pydantic import BaseModel
+
+router = APIRouter(prefix="/portfolio", tags=["Portfolio"])
+
+
+class PerformancePoint(BaseModel):
+    date: str
+    value: float
+
+
+@router.get("/performance", response_model=List[PerformancePoint])
+async def get_performance() -> List[PerformancePoint]:
+    """Return sample portfolio performance data."""
+    today = date.today()
+    data = [
+        PerformancePoint(date=str(today - timedelta(days=i)), value=10000 + i * 10)
+        for i in range(30, -1, -1)
+    ]
+    return data

--- a/openbb_platform/core/openbb_core/api/router/rag.py
+++ b/openbb_platform/core/openbb_core/api/router/rag.py
@@ -18,23 +18,24 @@ router = APIRouter(prefix="/rag", tags=["RAG"])
 DB_DIR = os.getenv("RAG_DB", "rag_db")
 EMBED_MODEL = os.getenv("EMBED_MODEL", "sentence-transformers/all-MiniLM-L6-v2")
 
+import logging
+
 embeddings = HuggingFaceEmbeddings(model_name=EMBED_MODEL)
 vector_db = Chroma(persist_directory=DB_DIR, embedding_function=embeddings)
 
+KNOWLEDGE_BASE_DIR = os.getenv("KNOWLEDGE_BASE_DIR", "knowledge_base/docs")
 
-+import logging
-+
-+
-+def load_docs(directory: str) -> List[Document]:
-+    logger = logging.getLogger(__name__)
-+    docs: List[Document] = []
-+    for path in glob.glob(os.path.join(directory, "*.txt")):
-+        try:
-+            with open(path, encoding="utf-8") as f:
-+                docs.append(Document(page_content=f.read()))
-+        except Exception as e:
-+            logger.warning(f"Could not read file {path}: {e}")
-+    return docs
+
+def load_docs(directory: str) -> List[Document]:
+    logger = logging.getLogger(__name__)
+    docs: List[Document] = []
+    for path in glob.glob(os.path.join(directory, "*.txt")):
+        try:
+            with open(path, encoding="utf-8") as f:
+                docs.append(Document(page_content=f.read()))
+        except Exception as exc:
+            logger.warning("Could not read file %s: %s", path, exc)
+    return docs
 
 
 @router.post("/ingest")

--- a/scripts/backtesting_agent.py
+++ b/scripts/backtesting_agent.py
@@ -1,4 +1,4 @@
-"""Backtesting agent placeholder."""
+"""Simplistic backtesting utilities."""
 
 import pandas as pd
 
@@ -7,11 +7,14 @@ from .trading_db import list_strategies, record_backtest
 
 
 def run_backtest(prices: pd.DataFrame) -> dict:
-    """Simple backtest: buy and hold return."""
+    """Simple buy-and-hold backtest."""
     if prices.empty:
         return {"return": 0.0}
 
     start = prices["close"].iloc[0]
+    end = prices["close"].iloc[-1]
+    if start == 0:
+        return {"return": 0.0}
 
     return {"return": (end - start) / start}
 
@@ -28,6 +31,9 @@ def run_strategy_backtest(
         raise ValueError(f"Strategy {strategy_id} not found")
 
     result = run_backtest(prices)
-
+    start_date = str(prices["date"].iloc[0]) if "date" in prices.columns else ""
+    end_date = str(prices["date"].iloc[-1]) if "date" in prices.columns else ""
+    record_backtest(strategy_id, start_date, end_date, result, conn_manager)
     return result
+
 

--- a/scripts/data_pipeline.py
+++ b/scripts/data_pipeline.py
@@ -1,8 +1,11 @@
-"""Data pipeline to fetch prices and load into a database."""
+"""Utilities for ingesting historical prices into a SQLite database."""
+
+from __future__ import annotations
+
 import pandas as pd
 from openbb import obb
 
-
+from .db_connections import ConnectionManager
 
 CREATE_TABLE_SQL = """
 CREATE TABLE IF NOT EXISTS prices (
@@ -13,41 +16,41 @@ CREATE TABLE IF NOT EXISTS prices (
     high REAL,
     low REAL,
     close REAL,
-
+    volume REAL,
+    UNIQUE(symbol, date)
 )
 """
 
-INSERT_SQL = """
-INSERT INTO prices (symbol, date, open, high, low, close, volume)
-VALUES (?, ?, ?, ?, ?, ?, ?)
-"""
+INSERT_SQL = (
+    "INSERT OR REPLACE INTO prices (symbol, date, open, high, low, close, volume)"
+    " VALUES (?, ?, ?, ?, ?, ?, ?)"
+)
 
 
 def fetch_equity(symbol: str, provider: str = "fmp") -> pd.DataFrame:
+    """Fetch historical prices using the OpenBB SDK."""
     data = obb.equity.price.historical(symbol=symbol, provider=provider)
     return data.to_dataframe()
 
 
 def load_prices(df: pd.DataFrame, conn_manager: ConnectionManager) -> None:
-
+    """Load price data into the database."""
     with conn_manager.context() as conn:
         conn.execute(CREATE_TABLE_SQL)
         conn.executemany(
             INSERT_SQL,
-
+            df[["symbol", "date", "open", "high", "low", "close", "volume"]].values.tolist(),
         )
         conn.commit()
 
 
 def preview_data(df: pd.DataFrame, n: int = 5) -> pd.DataFrame:
+    """Return a sample of the data for quick inspection."""
     return df.head(n)
 
 
 if __name__ == "__main__":  # pragma: no cover - manual execution
     cm = ConnectionManager({"database": "openbb.db"})
     prices = fetch_equity("AAPL")
-    preview = preview_data(prices)
-    for _, row in preview.iterrows():
-        pass  # placeholder for display
+    print(preview_data(prices))
     load_prices(prices, cm)
-

--- a/scripts/db_connections.py
+++ b/scripts/db_connections.py
@@ -1,3 +1,5 @@
+"""SQLite connection manager used by scripts."""
+
 import json
 import sqlite3
 from contextlib import contextmanager
@@ -7,13 +9,14 @@ from typing import Iterator, Optional
 CONFIG_DIR = Path(__file__).resolve().parent / "configs"
 CONFIG_DIR.mkdir(exist_ok=True)
 
-def list_config_files() -> list[Path]:
-    """Return a list of available connection configuration files."""
 
+def list_config_files() -> list[Path]:
+    """Return available connection configuration files."""
+    return list(CONFIG_DIR.glob("*.json"))
 
 
 def load_config(name: str) -> dict:
-    """Load a configuration file by name (without extension)."""
+    """Load a configuration file by name."""
     path = CONFIG_DIR / f"{name}.json"
     if not path.exists():
         raise FileNotFoundError(f"Config {name} not found")
@@ -21,30 +24,16 @@ def load_config(name: str) -> dict:
         return json.load(f)
 
 
+class ConnectionManager:
+    """Manage SQLite connections."""
 
-    """Manage database connections."""
-
-    def __init__(self, config: Optional[dict] = None):
+    def __init__(self, config: Optional[dict] = None) -> None:
         self.config = config or {}
-        self._conn: Optional[sqlite3.Connection] = None
-
-    def connect(self, config: Optional[dict] = None) -> sqlite3.Connection:
-        cfg = config or self.config
-        db_path = cfg.get("database", "openbb.db")
-        self._conn = sqlite3.connect(db_path)
-        self._conn.row_factory = sqlite3.Row
-        return self._conn
-
-    def close(self) -> None:
-        if self._conn:
-            self._conn.close()
-            self._conn = None
 
     @contextmanager
     def context(self, config: Optional[dict] = None) -> Iterator[sqlite3.Connection]:
-        conn = self.connect(config)
-        try:
+        cfg = config or self.config
+        db_path = cfg.get("database", "openbb.db")
+        with sqlite3.connect(db_path) as conn:
+            conn.row_factory = sqlite3.Row
             yield conn
-        finally:
-            self.close()
-

--- a/webapp/index.html
+++ b/webapp/index.html
@@ -2,21 +2,36 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-  <title>Realtime Price Viewer</title>
-  <script>
-    async function fetchPrice() {
-      const symbol = document.getElementById('symbol').value;
-      const res = await fetch(`/realtime/${symbol}`);
-      const data = await res.json();
-      document.getElementById('price').textContent =
-        `Symbol: ${data.symbol} Price: ${data.price} Timestamp: ${data.timestamp}`;
-    }
-  </script>
+  <title>OpenBB Demo</title>
+  <style>
+    body { font-family: Arial, sans-serif; background:#f4f4f4; margin:0; padding:0; }
+    header { background:#003366; color:#fff; padding:10px 20px; }
+    h1 { margin:0; }
+    nav ul { list-style:none; padding:0; margin:0; display:flex; }
+    nav li { margin-right:15px; }
+    nav a { color:#fff; text-decoration:none; }
+    main { padding:20px; }
+    section { margin-bottom:20px; background:#fff; padding:15px; border-radius:4px; }
+  </style>
 </head>
 <body>
-  <h1>Realtime Price Viewer</h1>
-  <input id="symbol" value="AAPL" />
-  <button onclick="fetchPrice()">Fetch Price</button>
-  <p id="price"></p>
+  <header>
+    <h1>OpenBB Platform</h1>
+    <nav>
+      <ul>
+        <li><a href="realtime.html">Realtime Prices</a></li>
+        <li><a href="portfolio.html">Portfolio</a></li>
+        <li><a href="research.html">Research</a></li>
+        <li><a href="rag.html">Knowledge Base</a></li>
+        <li><a href="news.html">News</a></li>
+      </ul>
+    </nav>
+  </header>
+  <main>
+    <section>
+      <h2>Welcome</h2>
+      <p>This demo highlights several modules of the OpenBB Platform. Use the navigation links above to explore realtime quotes, research reports, knowledge base chat, and news aggregation. The Portfolio page introduces simple performance tracking and backtesting.</p>
+    </section>
+  </main>
 </body>
 </html>

--- a/webapp/portfolio.html
+++ b/webapp/portfolio.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Portfolio Tracker</title>
+  <style>
+    body { font-family: Arial, sans-serif; }
+    #chart { width:100%; height:400px; }
+    table { border-collapse: collapse; width:100%; margin-top:10px; }
+    th, td { border:1px solid #ccc; padding:4px; }
+    th { background:#f0f0f0; }
+  </style>
+  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+  <script>
+    async function loadPortfolio() {
+      const res = await fetch('/portfolio/performance');
+      const data = await res.json();
+      const ctx = document.getElementById('chart').getContext('2d');
+      new Chart(ctx, {
+        type: 'line',
+        data: {
+          labels: data.map(d => d.date),
+          datasets: [{ label: 'Portfolio Value', data: data.map(d => d.value), borderColor: '#003366' }]
+        }
+      });
+      const tbody = document.getElementById('rows');
+      data.forEach(d => {
+        const tr = document.createElement('tr');
+        tr.innerHTML = `<td>${d.date}</td><td>${d.value.toFixed(2)}</td>`;
+        tbody.appendChild(tr);
+      });
+    }
+    window.onload = loadPortfolio;
+  </script>
+</head>
+<body>
+  <h1>Portfolio Performance</h1>
+  <canvas id="chart"></canvas>
+  <table>
+    <thead><tr><th>Date</th><th>Value</th></tr></thead>
+    <tbody id="rows"></tbody>
+  </table>
+</body>
+</html>

--- a/webapp/realtime.html
+++ b/webapp/realtime.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Realtime Price Viewer</title>
+  <script>
+    async function fetchPrice() {
+      const symbol = document.getElementById('symbol').value;
+      const res = await fetch(`/realtime/${symbol}`);
+      const data = await res.json();
+      document.getElementById('price').textContent =
+        `Symbol: ${data.symbol} Price: ${data.price} Timestamp: ${data.timestamp}`;
+    }
+  </script>
+</head>
+<body>
+  <h1>Realtime Price Viewer</h1>
+  <input id="symbol" value="AAPL" />
+  <button onclick="fetchPrice()">Fetch Price</button>
+  <p id="price"></p>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- build new index page with navigation
- add portfolio performance page
- implement historical price router
- add portfolio router
- secure news router with caching
- update REST API to load new routers
- provide data ingestion utilities and backtesting fixes

## Testing
- `ruff check .` *(fails: Invalid rule code etc.)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'openbb_core')*

------
https://chatgpt.com/codex/tasks/task_e_686e06388e78832a8b5115e0c9536911

## Summary by Sourcery

Introduce portfolio and historical price features, revamp front-end navigation, secure and cache news endpoints, and add data ingestion and backtesting utilities.

New Features:
- Add main index page with site-wide navigation links
- Implement Portfolio performance page using Chart.js
- Expose historical price data endpoint via a new API router
- Provide portfolio performance router for sample backtesting

Enhancements:
- Secure news endpoint with authentication hook and simple caching
- Refactor SQLite connection handling into a context manager
- Update data pipeline to support upserts and preview samples
- Enhance backtesting agent to record backtest date ranges
- Register new routers (history, portfolio, research, rag, news) in the REST API