### PR TITLE
Codex/create multi agent workflow for research reports

### DIFF
--- a/openbb_platform/core/openbb_core/api/router/research.py
+++ b/openbb_platform/core/openbb_core/api/router/research.py
@@ -10,7 +10,12 @@ router = APIRouter(prefix="/research", tags=["Research"])
 
 
 async def get_service() -> ResearchService:
-    """Dependency to get research service."""
+    """
+    Provides an instance of the ResearchService for dependency injection in FastAPI endpoints.
+    
+    Returns:
+        ResearchService: An instance of the research service.
+    """
     return ResearchService()
 
 
@@ -19,7 +24,15 @@ async def create_research(
     request: ResearchRequest,
     service: Annotated[ResearchService, Depends(get_service)],
 ) -> ResearchReport:
-    """Create a research report using the multi-agent workflow."""
+    """
+    Create a new research report based on the provided request data.
+    
+    Parameters:
+        request (ResearchRequest): The data required to generate the research report.
+    
+    Returns:
+        ResearchReport: The generated research report.
+    """
     return await service.create_report(request)
 
 
@@ -28,7 +41,17 @@ async def get_research(
     report_id: str,
     service: Annotated[ResearchService, Depends(get_service)],
 ) -> ResearchReport:
-    """Retrieve a research report by id."""
+    """
+    Retrieve a research report by its unique identifier.
+    
+    Raises an HTTP 404 exception if the report does not exist.
+    
+    Parameters:
+        report_id (str): The unique identifier of the research report to retrieve.
+    
+    Returns:
+        ResearchReport: The research report corresponding to the given ID.
+    """
     report = await service.get_report(report_id)
     if not report:
         raise HTTPException(status_code=404, detail="Report not found")

--- a/openbb_platform/core/openbb_core/app/service/research_service.py
+++ b/openbb_platform/core/openbb_core/app/service/research_service.py
@@ -15,10 +15,21 @@ class ResearchService(metaclass=SingletonMeta):
     """Service orchestrating research report generation."""
 
     def __init__(self) -> None:
+        """
+        Initialize the ResearchService with an empty dictionary for storing research reports.
+        """
         self._reports: Dict[str, ResearchReport] = {}
 
     async def create_report(self, request: ResearchRequest) -> ResearchReport:
-        """Create a research report placeholder."""
+        """
+        Generate a new research report with a unique ID and a default summary section based on the provided request topic.
+        
+        Parameters:
+            request (ResearchRequest): The research request containing the topic for the report.
+        
+        Returns:
+            ResearchReport: The newly created research report instance.
+        """
         section = ResearchSection(
             title="Summary",
             content=f"Automated summary for {request.topic}",
@@ -34,5 +45,13 @@ class ResearchService(metaclass=SingletonMeta):
         return report
 
     async def get_report(self, report_id: str) -> ResearchReport | None:
-        """Retrieve a stored research report."""
+        """
+        Retrieve a research report by its unique ID.
+        
+        Parameters:
+            report_id (str): The unique identifier of the research report.
+        
+        Returns:
+            ResearchReport | None: The corresponding research report if found, otherwise None.
+        """
         return self._reports.get(report_id)


### PR DESCRIPTION
# Pull Request OpenBB

Please go to the `Preview` tab and select the appropriate PR sub-template:

* [OpenBB Platform](?expand=1&template=platform_pull_request_template.md)
* [OpenBB Platform CLI](?expand=1&template=terminal_pull_request_template.md)
* [OpenBB Developers](?expand=1&template=obb_developer_pull_request_template.md)

## Summary by Sourcery

Remove database persistence from ResearchService, switch to in-memory report storage, and enhance documentation with detailed docstrings for service methods and API router endpoints.

Enhancements:
- Remove sqlite3 dependency and database initialization logic from ResearchService
- Add comprehensive docstrings to ResearchService methods
- Add comprehensive docstrings to FastAPI research router endpoints

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded and clarified docstrings for research-related functions and methods, providing more detailed descriptions of their behavior, parameters, and return values.

* **Refactor**
  * Removed the SQLite database initialization and persistence from the research service, shifting report storage to in-memory only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->